### PR TITLE
画像アップロード機能を追加 #22

### DIFF
--- a/app/Http/Controllers/Tweet/CreateController.php
+++ b/app/Http/Controllers/Tweet/CreateController.php
@@ -4,7 +4,7 @@ namespace App\Http\Controllers\Tweet;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Tweet\CreateRequest;
-use App\Models\Tweet;
+use App\Services\TweetService;
 
 class CreateController extends Controller
 {
@@ -14,12 +14,13 @@ class CreateController extends Controller
      * @param \Illuminate\Http\Request $request
      * @return \Illuminate\Http\RedirectResponse
      */
-    public function __invoke(CreateRequest $request)
+    public function __invoke(CreateRequest $request, TweetService $tweetService)
     {
-        $tweet = new Tweet;
-        $tweet->user_id = $request->userId();
-        $tweet->content = $request->tweet();
-        $tweet->save();
+        $tweetService->saveTweet(
+            $request->userId(),
+            $request->tweet(),
+            $request->images(),
+        );
         return redirect()->route('tweet.index');
     }
 }

--- a/app/Http/Controllers/Tweet/DeleteController.php
+++ b/app/Http/Controllers/Tweet/DeleteController.php
@@ -23,8 +23,7 @@ class DeleteController extends Controller
             return new AccessDeniedHttpException();
         }
 
-        $tweet = Tweet::where('id', $tweetId)->firstOrfail();
-        $tweet->delete();
+        $tweetService->deleteTweet($tweetId);
         return redirect()
             ->route('tweet.index')
             ->with('feedback.success', "つぶやきを削除しました");

--- a/app/Http/Controllers/Tweet/IndexController.php
+++ b/app/Http/Controllers/Tweet/IndexController.php
@@ -17,6 +17,8 @@ class IndexController extends Controller
     public function __invoke(Request $request, TweetService $tweetService)
     {
         $tweets = $tweetService->getTweets();
+//        dump($tweets);
+//        app(\App\Exceptions\Handler::class)->render(request(), throw new \Error('dump report.'));
         return view('tweet.index')->with('tweets', $tweets);
     }
 }

--- a/app/Http/Requests/Tweet/CreateRequest.php
+++ b/app/Http/Requests/Tweet/CreateRequest.php
@@ -24,7 +24,10 @@ class CreateRequest extends FormRequest
     public function rules()
     {
         return [
-            'tweet' => 'required|max:140'
+            'tweet' => 'required|max:140',
+            'images' => 'array|max:4',
+            // images配列の中身に対しての制約は[.*]を使って宣言する
+            'images.*' => 'required|image|mimes:jpeg,png,jpg,gif|max:2048'
         ];
     }
 
@@ -37,5 +40,11 @@ class CreateRequest extends FormRequest
     public function userId(): int
     {
         return $this->user()->id;
+    }
+
+    public function images(): array
+    {
+        // ファイル投稿なので、inputではなくfileで取得する
+        return $this->file('images', []);
     }
 }

--- a/app/Models/Image.php
+++ b/app/Models/Image.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Image extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Tweet.php
+++ b/app/Models/Tweet.php
@@ -9,10 +9,11 @@ class Tweet extends Model
 {
     use HasFactory;
 
-//    protected $primaryKey = 'tweet_id';
-
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+    public function images(){
+        return $this->belongsToMany(Image::class, 'tweet_images')->using(TweetImage::class);
     }
 }

--- a/app/Models/TweetImage.php
+++ b/app/Models/TweetImage.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class TweetImage extends Pivot
+{
+    //
+}

--- a/app/Services/TweetService.php
+++ b/app/Services/TweetService.php
@@ -2,14 +2,17 @@
 
 namespace App\Services;
 
+use App\Models\Image;
 use App\Models\Tweet;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
 
 class TweetService
 {
     public function getTweets()
     {
-        return Tweet::orderBy('created_at', 'DESC')->get();
+        return Tweet::with('images')->orderBy('created_at', 'DESC')->get();
     }
 
     /**
@@ -33,5 +36,41 @@ class TweetService
             Tweet::whereDate('created_at', '>=', Carbon::yesterday()->toDayDateTimeString())
                 ->whereDate('created_at', '<', Carbon::today()->toDateTimeString())
                 ->count();
+    }
+
+    public function saveTweet(int $userId, string $content, array $images)
+    {
+        DB::transaction(
+            function () use ($userId, $content, $images) {
+                $tweet = new Tweet();
+                $tweet->user_id = $userId;
+                $tweet->content = $content;
+                $tweet->save();
+                // つぶやきを保存後、画像を保存
+                foreach ($images as $image) {
+                    Storage::putFile('public/images', $image);
+                    $imageModel = new Image();
+                    $imageModel->name = $image->hashName();
+                    $imageModel->save();
+                    $tweet->images()->attach($imageModel->id);
+                }
+            }
+        );
+    }
+
+    public function deleteTweet(int $tweetId)
+    {
+        DB::transaction(function () use ($tweetId) {
+            $tweet = Tweet::where('id', $tweetId)->firstOrFail();
+            $tweet->images()->each(function ($image) use ($tweet) {
+                $filePath = 'public/images/' . $image->name;
+                if (Storage::exists($filePath)) {
+                    Storage::delete($filePath);
+                }
+                $tweet->images()->detach($image->id);
+                $image->delete();
+            });
+            $tweet->delete();
+        });
     }
 }

--- a/database/factories/ImageFactory.php
+++ b/database/factories/ImageFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Image>
+ */
+class ImageFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        // ディレクトリがなければ作成する
+        if (!Storage::exists('public/images')) {
+            Storage::makeDirectory('public/images');
+        }
+        return [
+            'name' => $this->faker->image(storage_path('app/public/images'),
+                640, 480, null, false)
+        ];
+    }
+}

--- a/database/factories/TweetImageFactory.php
+++ b/database/factories/TweetImageFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\TweetImage>
+ */
+class TweetImageFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/database/migrations/2022_04_26_112924_create_images_table.php
+++ b/database/migrations/2022_04_26_112924_create_images_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('images', function (Blueprint $table) {
+            $table->id();
+            $table->String('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('images');
+    }
+};

--- a/database/migrations/2022_04_26_113253_create_tweet_images_table.php
+++ b/database/migrations/2022_04_26_113253_create_tweet_images_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tweet_images', function (Blueprint $table) {
+            $table->foreignId('tweet_id')->constrained('tweets')->cascadeOnDelete();
+            $table->foreignId('image_id')->constrained('images')->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tweet_images');
+    }
+};

--- a/database/seeders/TweetsSeeder.php
+++ b/database/seeders/TweetsSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Image;
 use App\Models\Tweet;
 use Illuminate\Database\Seeder;
 
@@ -14,6 +15,9 @@ class TweetsSeeder extends Seeder
      */
     public function run()
     {
-        Tweet::factory()->count(10)->create();
+        // 10件のつぶやきレコードを作成し、それぞれのつぶやきに4枚の画像を紐付ける
+        Tweet::factory()->count(10)->create()->each(fn($tweet) =>
+        Image::factory()->count(4)->create()->each(fn($image) =>
+        $tweet->images()->attach($image->id)));
     }
 }

--- a/resources/views/components/tweet/form/images.blade.php
+++ b/resources/views/components/tweet/form/images.blade.php
@@ -1,0 +1,44 @@
+<div x-data="inputFormHandler()" class="my-2">
+    <template x-for="(field, i) in fields" :key="i">
+        <div class="w-full flex my-2">
+            <label :for="field.id" class="border border-gray-300 rounded-md p-2 w-full bg-white cursor-pointer">
+                <input type="file" accept="image/*" class="sr-only" :id="field.id" name="images[]"
+                       @change="fields[i].file = $event.target.files[0]">
+                <span x-text="field.file ? field.file.name : '画像を選択'" class="text-gray-700"></span>
+            </label>
+            <button type="reset" @click="removeField(i)" class="p-2">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
+                </svg>
+            </button>
+        </div>
+    </template>
+
+    <template x-if="fields.length < 4">
+        <button type="button" @click="addField()"
+                class="inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-gray-500 hover:bg-gray-600">
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                <path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd" />
+            </svg>
+            <span>画像を追加</span>
+        </button>
+    </template>
+</div>
+
+<script>
+    function inputFormHandler() {
+        return {
+            fields: [],
+            addField() {
+                const i = this.fields.length;
+                this.fields.push({
+                    file: '',
+                    id: `input-image-${i}`
+                });
+            },
+            removeField(index) {
+                this.fields.splice(index, 1);
+            }
+        }
+    }
+</script>

--- a/resources/views/components/tweet/form/post.blade.php
+++ b/resources/views/components/tweet/form/post.blade.php
@@ -1,6 +1,6 @@
 @auth
     <div class="p-4">
-        <form action="{{ route('tweet.create') }}" method="post">
+        <form action="{{ route('tweet.create') }}" method="post" enctype="multipart/form-data">
             @csrf
             <div class="mt-1">
 
@@ -9,6 +9,7 @@
                       placeholder="つぶやきを入力"></textarea>
             </div>
             <p class="mt-2 text-gray-500">140文字まで</p>
+            <x-tweet.form.images></x-tweet.form.images>
 
             @error('tweet')
             <x-alert.error>{{ $message }}</x-alert.error>

--- a/resources/views/components/tweet/images.blade.php
+++ b/resources/views/components/tweet/images.blade.php
@@ -1,0 +1,60 @@
+@props([
+    'images' => []
+])
+
+@if(isset($images) && count($images) > 0)
+    <div x-data="{}" class="px-2">
+        <div class="flex justify-center -mx-2">
+            @foreach($images as $image)
+                <div class="w-1/6 px-2 mt-5">
+                    <div class="bg-gray-400">
+                        <a @click="$dispatch('img-modal', { imgModalSrc: '{{ asset('storage/images/' . $image->name) }}' })"
+                           class="cursor-pointer">
+                            <img alt="{{ $image->name }}" class="object-fit w-full"
+                                 src="{{ asset('storage/images/' . $image->name) }}">
+                        </a>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </div>
+@endif
+@once
+    <div x-data="{ img Modal : false, imgModalSrc : '' }">
+        <div
+            @img-modal.window="imgModal = true; imgModalSrc = $event.detail.imgModalSrc;" x-cloak x-show="imgModal"
+            x-transition:enter="transition ease-out duration-300" x-transition:enter-start="opacity-o transform"
+            X-transition:enter-end="opacity-100 transform" x-transition:leave="transition ease-in duration-300"
+            x-transition:leave-start="opacity-100 transform" X-transition:leave-end="opacity-o transform"
+            x-on:click.away="imgModalSrc = ''" class="p-2 fixed w-full h-100 inset-o z-50 overflow-hidden flex justify-center items-center bg-black
+        bg-opacity-75">
+            <div @click.away="imgModal = ''" class="flex flex-col max-w-3xl max-h-full overflow-auto">
+                <div class="z-50">
+                    <button @click="imgModal = ''" class="float-right pt-2 pr-2 outline-none focus:outline-none">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+                            <path fill-rule="evenodd"
+                                  d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z"
+                                  clip-rule="evenodd"/>
+                        </svg>
+                        <path fill-rule="evenodd"
+                              d="M4.293 4.293 al 1 O 011.414 OL10 8.58614.293-4.293 al 1 0 111.414 1.414L11.414 1014.293 4.293 al 1 O 01-1.414 1.414L10 11.4141-4.293 4.293 al 1 0 01-1.4141.414L8.586 10 4.293 5.707al 1 0 010-1.414z"
+                              clip-rule="evenodd"/>
+                        </svg>
+                    </button>
+                </div>
+                <div class="p-2">
+                    <img class="object-contain h-1/2-screen"
+                         :alt="imgModalSrc"
+                         :Isrc="imgModalSrc">
+                </div>
+            </div>
+        </div>
+    </div>
+    @push('css')
+        <style>
+            [x-cloak] {
+                display: none !important;
+            }
+        </style>
+    @endpush
+@endonce

--- a/resources/views/components/tweet/list.blade.php
+++ b/resources/views/components/tweet/list.blade.php
@@ -12,6 +12,7 @@
                     <p class="text-gray-600">
                         {!! nl2br(e($tweet->content)) !!}
                     </p>
+                    <x-tweet.images :images="$tweet->images"/>
                 </div>
                 <div>
                     <x-tweet.options :tweet-id="$tweet->id" :user-id="$tweet->user_id"></x-tweet.options>


### PR DESCRIPTION
つぶやきと一緒に画像を一種に投稿できるようにしました。
追加した機能は以下です。

1. 画像投稿用テストデータのマイグレーションファイルを作成
2. 画面側に画像添付フォームを追加
3. つぶやき時、画像を４枚まで添付可能なように設定
4. つぶやき削除時に画像も一緒に削除されるように変更

![image](https://user-images.githubusercontent.com/25398427/165244265-eeef1aa6-5731-4839-ab44-c51f6b9b1b67.png)
